### PR TITLE
[WIP] Avoid encoding during hash calculation

### DIFF
--- a/src/CAServer.Application/Verifier/VerifierAppService.cs
+++ b/src/CAServer.Application/Verifier/VerifierAppService.cs
@@ -399,27 +399,19 @@ public class VerifierAppService : CAServerAppService, IVerifierAppService
     private Hash GetHash(byte[] identifier, byte[] salt)
     {
         const int maxIdentifierLength = 256;
-        const int requiredSaltLength = 16;
+        const int maxSaltLength = 16;
 
         if (identifier.Length > maxIdentifierLength)
         {
             throw new Exception("Identifier is too long");
         }
 
-        if (salt.Length != requiredSaltLength)
+        if (salt.Length != maxSaltLength)
         {
-            throw new Exception($"Salt has to be {requiredSaltLength} bytes.");
+            throw new Exception($"Salt has to be {maxSaltLength} bytes.");
         }
-        var hash = HashHelper.ComputeFrom(PadByteArrayToLength(identifier, maxIdentifierLength));
-        return HashHelper.ComputeFrom(salt.Concat(hash).ToArray());
-        
-        byte[] PadByteArrayToLength(byte[] originalArray, int targetLength)
-        {
-            var paddedArray = new byte[targetLength];
-            Array.Copy(originalArray, paddedArray, Math.Min(originalArray.Length, targetLength));
-
-            return paddedArray;
-        }
+        var hash = HashHelper.ComputeFrom(identifier);
+        return HashHelper.ComputeFrom(hash.Concat(salt).ToArray());
     }
 
     private async Task<GoogleUserInfoDto> GetUserInfoFromGoogleAsync(string accessToken)

--- a/src/CAServer.Application/Verifier/VerifierAppService.cs
+++ b/src/CAServer.Application/Verifier/VerifierAppService.cs
@@ -320,7 +320,7 @@ public class VerifierAppService : CAServerAppService, IVerifierAppService
         {
             salt = GetSalt().ToHex();
             identifierHash = GetHash( Encoding.UTF8.GetBytes(requestInput.GuardianIdentifier),  
-                ByteStringHelper.FromHexString(requestInput.Salt).ToByteArray()).ToHex();
+                ByteArrayHelper.HexStringToByteArray(requestInput.Salt)).ToHex();
         }
 
         requestInput.Salt = salt;


### PR DESCRIPTION
We don't find existing libraries for handling UTF8 and Hex encoding and decoding in Circom. So it's better to keep using byte array as much as possible and avoid encoding/decoding as much as possible. It's also cheaper in execution as it's costly and slow to put more logics in the circuit.