### PR TITLE
refactor: ♻️ register email rate-limit dependencies manually

### DIFF
--- a/src/CAServer.Application/CAServerApplicationModule.cs
+++ b/src/CAServer.Application/CAServerApplicationModule.cs
@@ -30,6 +30,7 @@ using CAServer.Tokens.Provider;
 using CAServer.Telegram.Options;
 using CAServer.ThirdPart.Processor.Treasury;
 using CAServer.TwitterAuth;
+using CAServer.Verifier;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -159,6 +160,7 @@ public class CAServerApplicationModule : AbpModule
             .ValidateOnStart();
         context.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<RegistrationEmailRateLimitOptions>, RegistrationEmailRateLimitOptionsValidator>());
+        context.Services.AddTransient<IRegistrationEmailRateLimitService, RegistrationEmailRateLimitService>();
         Configure<PhoneInfoOptions>(configuration.GetSection("PhoneInfoOptions"));
         Configure<ClaimTokenWhiteListAddressesOptions>(configuration.GetSection("ClaimTokenWhiteListAddresses"));
         Configure<ClaimTokenInfoOptions>(configuration.GetSection("ClaimTokenInfo"));

--- a/src/CAServer.Application/Verifier/RegistrationEmailRateLimitService.cs
+++ b/src/CAServer.Application/Verifier/RegistrationEmailRateLimitService.cs
@@ -6,11 +6,10 @@ using CAServer.CAAccount.Dtos;
 using CAServer.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Volo.Abp.DependencyInjection;
 
 namespace CAServer.Verifier;
 
-public class RegistrationEmailRateLimitService : IRegistrationEmailRateLimitService, ITransientDependency
+public class RegistrationEmailRateLimitService : IRegistrationEmailRateLimitService
 {
     private const string CacheKeyPrefix = "RegistrationEmailRateLimit";
     private static readonly TimeSpan TenMinuteWindow = TimeSpan.FromMinutes(10);

--- a/src/CAServer.HttpApi/CAServerHttpApiModule.cs
+++ b/src/CAServer.HttpApi/CAServerHttpApiModule.cs
@@ -1,5 +1,8 @@
 ﻿using Localization.Resources.AbpUi;
+using CAServer.IpInfo;
 using CAServer.Localization;
+using CAServer.Verifier;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Account;
 using Volo.Abp.FeatureManagement;
 using Volo.Abp.Identity;
@@ -26,6 +29,11 @@ public class CAServerHttpApiModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.AddTransient<IHttpClientIpResolver, HttpClientIpResolver>();
+        context.Services.AddTransient<IVerificationRequestRiskControlService, VerificationRequestRiskControlService>();
+        context.Services.AddTransient<IVerificationRequestOperationDispatcher, VerificationRequestOperationDispatcher>();
+        context.Services.AddTransient<IVerificationRequestOperationHandler, CreateCaHolderVerificationRequestHandler>();
+        context.Services.AddTransient<IVerificationRequestOperationHandler, SocialRecoveryVerificationRequestHandler>();
         ConfigureLocalization();
     }
 

--- a/src/CAServer.HttpApi/IpInfo/HttpClientIpResolver.cs
+++ b/src/CAServer.HttpApi/IpInfo/HttpClientIpResolver.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using Volo.Abp.DependencyInjection;
 
 namespace CAServer.IpInfo;
 
-public class HttpClientIpResolver : IHttpClientIpResolver, ITransientDependency
+public class HttpClientIpResolver : IHttpClientIpResolver
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly RealIpOptions _realIpOptions;

--- a/src/CAServer.HttpApi/Verifier/CreateCaHolderVerificationRequestHandler.cs
+++ b/src/CAServer.HttpApi/Verifier/CreateCaHolderVerificationRequestHandler.cs
@@ -1,12 +1,11 @@
 using System.Threading.Tasks;
 using CAServer.IpInfo;
 using Microsoft.Extensions.Logging;
-using Volo.Abp.DependencyInjection;
 
 namespace CAServer.Verifier;
 
 public class CreateCaHolderVerificationRequestHandler : RegistrationEmailRateLimitedOperationHandlerBase,
-    IVerificationRequestOperationHandler, ITransientDependency
+    IVerificationRequestOperationHandler
 {
     private readonly IVerifierAppService _verifierAppService;
 

--- a/src/CAServer.HttpApi/Verifier/SocialRecoveryVerificationRequestHandler.cs
+++ b/src/CAServer.HttpApi/Verifier/SocialRecoveryVerificationRequestHandler.cs
@@ -2,12 +2,11 @@ using System;
 using System.Threading.Tasks;
 using CAServer.IpInfo;
 using CAServer.Switch;
-using Volo.Abp.DependencyInjection;
 
 namespace CAServer.Verifier;
 
 public class SocialRecoveryVerificationRequestHandler : RegistrationEmailRateLimitedOperationHandlerBase,
-    IVerificationRequestOperationHandler, ITransientDependency
+    IVerificationRequestOperationHandler
 {
     private readonly IVerificationRequestRiskControlService _verificationRequestRiskControlService;
     private readonly ISwitchAppService _switchAppService;

--- a/src/CAServer.HttpApi/Verifier/VerificationRequestOperationDispatcher.cs
+++ b/src/CAServer.HttpApi/Verifier/VerificationRequestOperationDispatcher.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Volo.Abp.DependencyInjection;
 
 namespace CAServer.Verifier;
 
-public class VerificationRequestOperationDispatcher : IVerificationRequestOperationDispatcher, ITransientDependency
+public class VerificationRequestOperationDispatcher : IVerificationRequestOperationDispatcher
 {
     private readonly IReadOnlyDictionary<OperationType, IVerificationRequestOperationHandler> _handlers;
 

--- a/src/CAServer.HttpApi/Verifier/VerificationRequestRiskControlService.cs
+++ b/src/CAServer.HttpApi/Verifier/VerificationRequestRiskControlService.cs
@@ -9,13 +9,12 @@ using CAServer.IpInfo;
 using CAServer.IpWhiteList;
 using CAServer.Switch;
 using Microsoft.Extensions.Logging;
-using Volo.Abp.DependencyInjection;
 using Volo.Abp;
 using Volo.Abp.Users;
 
 namespace CAServer.Verifier;
 
-public class VerificationRequestRiskControlService : IVerificationRequestRiskControlService, ITransientDependency
+public class VerificationRequestRiskControlService : IVerificationRequestRiskControlService
 {
     private readonly ICurrentUser _currentUser;
     private readonly IGoogleAppService _googleAppService;

--- a/test/CAServer.HttpApi.Tests/DependencyRegistrationTests.cs
+++ b/test/CAServer.HttpApi.Tests/DependencyRegistrationTests.cs
@@ -1,0 +1,105 @@
+using System.Linq;
+using CAServer.Cache;
+using CAServer.CAAccount;
+using CAServer.Google;
+using CAServer.IpInfo;
+using CAServer.IpWhiteList;
+using CAServer.Options;
+using CAServer.Switch;
+using CAServer.Verifier;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Users;
+
+namespace CAServer.HttpApi.Tests;
+
+public class DependencyRegistrationTests
+{
+    [Fact]
+    public void Email_RateLimit_Feature_Types_Should_Not_Implement_ITransientDependency()
+    {
+        var featureTypes = new[]
+        {
+            typeof(RegistrationEmailRateLimitService),
+            typeof(HttpClientIpResolver),
+            typeof(VerificationRequestOperationDispatcher),
+            typeof(VerificationRequestRiskControlService),
+            typeof(CreateCaHolderVerificationRequestHandler),
+            typeof(SocialRecoveryVerificationRequestHandler)
+        };
+
+        foreach (var featureType in featureTypes)
+        {
+            Assert.DoesNotContain(typeof(ITransientDependency), featureType.GetInterfaces());
+        }
+    }
+
+    [Fact]
+    public void Email_RateLimit_Feature_Dependencies_Should_Be_Resolvable_From_Manual_Transient_Registrations()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        });
+        services.AddSingleton<IOptions<RealIpOptions>>(Microsoft.Extensions.Options.Options.Create(new RealIpOptions
+        {
+            HeaderKey = ClientIpHeaders.XForwardedFor,
+            AllowLegacyForwardedFallback = true
+        }));
+        services.AddSingleton<IOptionsSnapshot<RegistrationEmailRateLimitOptions>>(
+            new StaticOptionsSnapshot<RegistrationEmailRateLimitOptions>(new RegistrationEmailRateLimitOptions()));
+        services.AddSingleton(Mock.Of<ICacheProvider>());
+        services.AddSingleton(Mock.Of<ICurrentUser>());
+        services.AddSingleton(Mock.Of<IGoogleAppService>());
+        services.AddSingleton(Mock.Of<IIpWhiteListAppService>());
+        services.AddSingleton(Mock.Of<ISecondaryEmailAppService>());
+        services.AddSingleton(Mock.Of<ISwitchAppService>());
+        services.AddSingleton(Mock.Of<IVerifierAppService>());
+
+        services.AddTransient<IRegistrationEmailRateLimitService, RegistrationEmailRateLimitService>();
+        services.AddTransient<IHttpClientIpResolver, HttpClientIpResolver>();
+        services.AddTransient<IVerificationRequestRiskControlService, VerificationRequestRiskControlService>();
+        services.AddTransient<IVerificationRequestOperationDispatcher, VerificationRequestOperationDispatcher>();
+        services.AddTransient<IVerificationRequestOperationHandler, CreateCaHolderVerificationRequestHandler>();
+        services.AddTransient<IVerificationRequestOperationHandler, SocialRecoveryVerificationRequestHandler>();
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.IsType<RegistrationEmailRateLimitService>(
+            serviceProvider.GetRequiredService<IRegistrationEmailRateLimitService>());
+        Assert.IsType<HttpClientIpResolver>(serviceProvider.GetRequiredService<IHttpClientIpResolver>());
+        Assert.IsType<VerificationRequestRiskControlService>(
+            serviceProvider.GetRequiredService<IVerificationRequestRiskControlService>());
+        Assert.IsType<VerificationRequestOperationDispatcher>(
+            serviceProvider.GetRequiredService<IVerificationRequestOperationDispatcher>());
+
+        var handlers = serviceProvider.GetServices<IVerificationRequestOperationHandler>().ToList();
+
+        Assert.Equal(2, handlers.Count);
+        Assert.Single(handlers.OfType<CreateCaHolderVerificationRequestHandler>());
+        Assert.Single(handlers.OfType<SocialRecoveryVerificationRequestHandler>());
+    }
+
+    private sealed class StaticOptionsSnapshot<TOptions> : IOptionsSnapshot<TOptions>
+        where TOptions : class
+    {
+        public StaticOptionsSnapshot(TOptions value)
+        {
+            Value = value;
+        }
+
+        public TOptions Value { get; }
+
+        public TOptions Get(string? name)
+        {
+            return Value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove email rate-limit feature classes from ABP convention-based transient registration
- register the related services and handlers explicitly in modules with AddTransient
- add a DI smoke test to lock the manual wiring and handler collection shape

## Testing
- dotnet test test/CAServer.HttpApi.Tests/CAServer.HttpApi.Tests.csproj --filter "DependencyRegistrationTests|VerificationRequestOperationHandlerTests|CAVerifierControllerTests|DeviceInfoMiddlewareTests|RealIpMiddlewareTests|RealIpOptionsValidatorTests" -nologo
- dotnet test test/CAServer.Application.Tests/CAServer.Application.Tests.csproj --filter "RegistrationEmailRateLimitServiceTests|HttpClientIpResolverTests" -nologo